### PR TITLE
Fix for Ruby 3.0: use double splat to pass hashes as args

### DIFF
--- a/lib/xrandr.rb
+++ b/lib/xrandr.rb
@@ -1,5 +1,5 @@
 module Xrandr
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 
   class Control
     attr_reader :screens, :outputs, :command
@@ -100,7 +100,7 @@ module Xrandr
 
       args[:modes] = args[:connected] ? parse_modes(modes) : []
 
-      Output.new args
+      Output.new(**args)
     end
 
     def parse_modes(modes)
@@ -120,7 +120,7 @@ module Xrandr
               preferred: matches[:preferred] == '+',
              }
 
-      Mode.new args
+      Mode.new(**args)
     end
   end
 


### PR DESCRIPTION
Because of this in Ruby 3.0:

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

versions 3.0 and beyond break like this:
```
pry(main)> Xrandr::Control.new
ArgumentError: wrong number of arguments (given 1, expected 0; required keywords: name, connected)
```

This PR fixes that by using double splats where it's now required.